### PR TITLE
Handle REPL panics to keep session alive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 #![feature(rustc_private)]
+use rust_repl::run;
 use rustyline::error::ReadlineError;
 use rustyline::{DefaultEditor, Result};
-use rust_repl::run;
+use std::panic;
 
 fn repl() -> Result<()> {
     let mut rl = DefaultEditor::new()?;
@@ -11,25 +12,39 @@ fn repl() -> Result<()> {
         match readline {
             Ok(line) => {
                 let _ = rl.add_history_entry(line.as_str());
-                let src_code = format!(r#"
+                let src_code = format!(
+                    r#"
                 fn main() {{
                         {}
                     }}
-                "#, line.clone());
+                "#,
+                    line.clone()
+                );
 
-                run(src_code);
-            },
+                // Run user input in a separate panic catcher so that
+                // compilation or runtime errors don't terminate the REPL.
+                if let Err(err) = panic::catch_unwind(|| run(src_code)) {
+                    // `run` already prints diagnostics, but a panic may still carry
+                    // a message. Display it for additional context.
+                    if let Some(msg) = err.downcast_ref::<&str>() {
+                        eprintln!("Error: {}", msg);
+                    } else if let Some(msg) = err.downcast_ref::<String>() {
+                        eprintln!("Error: {}", msg);
+                    }
+                    // Continue looping to allow the user to try again.
+                }
+            }
             Err(ReadlineError::Interrupted) => {
                 println!("CTRL-C");
-                break
-            },
+                break;
+            }
             Err(ReadlineError::Eof) => {
                 println!("CTRL-D");
-                break
-            },
+                break;
+            }
             Err(err) => {
                 println!("Error: {:?}", err);
-                break
+                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent REPL from exiting on compilation/runtime errors by catching panics

## Testing
- `cargo test` *(fails: failed to load source for dependency `rustc_codegen_cranelift`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f801f86083319e3e73f9f570f694