### PR TITLE
Support newline insertion with Ctrl+J

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 #![feature(rustc_private)]
 use rust_repl::run;
 use rustyline::error::ReadlineError;
-use rustyline::{DefaultEditor, Result};
+use rustyline::{Cmd, DefaultEditor, KeyEvent, Result};
 use std::panic;
 
 fn repl() -> Result<()> {
     let mut rl = DefaultEditor::new()?;
+    rl.bind_sequence(KeyEvent::ctrl('j'), Cmd::Newline);
 
     loop {
         let readline = rl.readline(">> ");


### PR DESCRIPTION
## Summary
- Allow Ctrl+J in the REPL to insert a newline without executing code

## Testing
- `cargo test` *(fails: failed to load source for dependency `rustc_codegen_cranelift`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd106e3483319023c402a3ed1cc3